### PR TITLE
add layer state management

### DIFF
--- a/ramp/src/classes/LayerState.js
+++ b/ramp/src/classes/LayerState.js
@@ -1,0 +1,66 @@
+export class LayerState {
+  constructor(name, parent, options) {
+    this.name = name;
+    this.parent = parent;
+    this.children = [];
+
+    // legend state
+    this.expandable = options ? !!options.expandable : true;
+    this.expanded = options ? !!options.expanded : true;
+
+    this.toggleable = options ? !!options.toggleable : true;
+    this.toggled = true;
+    this.wasToggled = false;
+  }
+
+  addChild(node) {
+    this.children.push(node);
+  }
+
+  toggle(val, propagate = true) {
+    this.toggled = val != undefined ? val : !this.toggled;
+
+    if (val == undefined) {
+      this.wasToggled = false;
+    }
+
+    // determines whether any children were toggled on prior to this element being toggled off
+    const toggledChildren = this.children ? this.children.some(child => child.toggleable && child.wasToggled) : false;
+
+    if (this.toggled) {
+      if (this.parent && !this.parent.toggled) {
+        this.parent.toggle(true, false);
+      }
+
+      // handles cases where the parent is toggled ON
+
+      if (!propagate) return;
+      this.children.forEach(child => {
+        if (!toggledChildren) {
+          child.toggle(true);
+        } else if (child.wasToggled) {
+          child.toggle(this.toggled);
+        } else {
+          child.wasToggled = false;
+        }
+      });
+    } else {
+      // handles cases where the parent is toggled OFF
+
+      // determines whether any siblings are toggled on
+      const toggledSiblings = this.parent && this.parent.children.some(child => child.toggleable && child.toggled);
+
+      if (this.parent && !toggledSiblings) {
+        this.parent.toggle(false, false);
+      }
+
+      if (!propagate) return;
+      this.children.forEach(child => {
+        if (child.toggled) {
+          child.wasToggled = true;
+        }
+        child.toggle(false);
+      });
+    }
+  }
+}

--- a/ramp/src/components/LeafComponent.vue
+++ b/ramp/src/components/LeafComponent.vue
@@ -1,18 +1,6 @@
 <template>
   <div class="rvDropdown">
-    <div class="rvDropdownTitle noselect" v-on:click="click">
-      <!-- icon -->
-      <i
-        id="icon"
-        :class="{ 'rotate-180' : expanded }"
-        class="md-icon md-icon-font md-icon-image md-list-expand-icon md-theme-default"
-      >
-        <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-          <path d="M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z" />
-          <path d="M0-.75h24v24H0z" fill="none" />
-        </svg>
-      </i>
-
+    <div class="rvDropdownTitle noselect">
       <!-- name -->
       <span>{{ element.name }}</span>
 
@@ -54,24 +42,15 @@
 
 <script>
 export default {
-  name: "DropdownComponent",
+  name: "LeafComponent",
   props: ["element"],
   data: function() {
     return {
-      expanded: this.element.expanded,
-      toggled: false,
-      clickedToggle: false
+      toggled: false
     };
   },
   methods: {
-    click: function() {
-      if (!this.clickedToggle) {
-        this.expanded = !this.expanded;
-      }
-      this.clickedToggle = false;
-    },
     toggle: function() {
-      this.clickedToggle = true;
       this.element.toggle();
     }
   }

--- a/ramp/src/components/Legend.vue
+++ b/ramp/src/components/Legend.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="rv-legend">
     <LegendHeader></LegendHeader>
-    <LegendComponent v-for="node in nodes" v-bind:key="node.name" :element="node"></LegendComponent>
+    <LegendComponent :element="root"></LegendComponent>
 
     <!--
     <DropdownComponent title="Root">
@@ -30,7 +30,7 @@ export default {
   },
   data: function() {
     return {
-      nodes: this.$store.state.legendComponents
+      root: this.$store.state.legendComponents
     };
   }
 };

--- a/ramp/src/components/LegendComponent.vue
+++ b/ramp/src/components/LegendComponent.vue
@@ -1,7 +1,7 @@
 <template>
   <ul style="list-style: none; margin: 8px; padding: 0px;">
     <li class="rvTreeComponent">
-      <DropdownComponent :element="element" v-if="element.children">
+      <DropdownComponent :element="element" v-if="element.children.length > 0">
         <LegendComponent
           class="md-inset"
           v-for="node in element.children"
@@ -13,19 +13,21 @@
       <div class="rvTreeComponentLeaf" v-else-if="element.infoType === 'image'">
         <img :src="element.content" :alt="element.name" :title="element.name" />
       </div>
-      <div class="rvTreeComponentLeaf" v-else>{{ element.name }}</div>
+      <LeafComponent :element="element" v-else>{{ element.name }}</LeafComponent>
     </li>
   </ul>
 </template>
 
 <script>
 import DropdownComponent from "./DropdownComponent";
+import LeafComponent from "./LeafComponent";
 
 export default {
   name: "LegendComponent",
   props: ["element"],
   components: {
-    DropdownComponent
+    DropdownComponent,
+    LeafComponent
   }
 };
 </script>

--- a/ramp/src/main.js
+++ b/ramp/src/main.js
@@ -3,50 +3,24 @@ import Vuex from 'vuex';
 import VueMaterial from 'vue-material';
 import 'vue-material/dist/vue-material.min.css';
 import App from './App.vue';
+import { LayerState } from './classes/LayerState.js';
 
 Vue.use(VueMaterial);
 Vue.use(Vuex);
 
 Vue.config.productionTip = false;
 
-let root = [
-  {
-    name: 'Root',
-    toggled: false,
-    wasToggled: false,
-    children: [
-      {
-        content: 'This is some text content.',
-        infoType: 'text'
-      },
-      {
-        content: 'https://i.imgur.com/ojcd4xn.png',
-        infoType: 'image',
-        name: 'This is an image'
-      },
-      {
-        name: 'Child 1',
-        toggled: false,
-        wasToggled: false,
-        children: [
-          {
-            name: "Child's Child 1"
-          }
-        ]
-      },
-      {
-        name: 'Child 2',
-        toggled: false,
-        wasToggled: false,
-        children: [
-          {
-            name: "Child's Child 2"
-          }
-        ]
-      }
-    ]
-  }
-];
+let root = new LayerState('Root', null);
+let child = new LayerState('Child', root, { expanded: false });
+child.addChild(new LayerState("Child's Child1", child));
+child.addChild(new LayerState("Child's Child2", child));
+
+let child2 = new LayerState('Child1', root);
+child2.addChild(new LayerState("Child's Child1", child2));
+child2.addChild(new LayerState("Child's Child2", child2));
+
+root.addChild(child);
+root.addChild(child2);
 
 const store = new Vuex.Store({
   state: {
@@ -56,13 +30,9 @@ const store = new Vuex.Store({
     getEntries: state => state.legendComponents
   },
   mutations: {
-    ADD_ENTRY (state, payload) {
+    ADD_ENTRY(state, payload) {
       // maybe need to check for duplicates
-      const newEntry = {
-        name: payload.name,
-        children: []
-      };
-      state.legendComponents.push(newEntry);
+      state.legendComponents.addChild(new LayerState(payload.name, root));
     }
   },
   actions: {


### PR DESCRIPTION
This PR adds a basic layer state manager. It also introduces a couple of smaller changes:
- changed `nodes` to `root` in Legend.vue to better reflect what is being passed in to the component
- added a LeafComponent to the legend, which does not display the option to expand/collapse
- layers are now expanded by default
- toggle logic now occurs in the LayerState class

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rcsideprojects/ramp-vue-testing/18)
<!-- Reviewable:end -->
