### PR TITLE
Fix toggle parent bug

### DIFF
--- a/ramp/src/classes/LayerState.js
+++ b/ramp/src/classes/LayerState.js
@@ -113,9 +113,15 @@ export class LayerState {
     if (this.toggled) {
       if (this.parent && !this.parent.toggled) {
         this.parent.toggle(true, false);
+
+        this.parent.children.forEach(child => {
+          if(this !== child) {
+            child.wasToggled = false;
+          }
+        })
       }
 
-      // handles cases where the parent is toggled ON
+      // handles cases where the layer is toggled ON
       if (!propagate) return;
       this.children.forEach(child => {
         if (!toggledChildren) {
@@ -127,7 +133,7 @@ export class LayerState {
         }
       });
     } else {
-      // handles cases where the parent is toggled OFF
+      // handles cases where the layer is toggled OFF
       // determines whether any siblings are toggled on
       const toggledSiblings = this.parent && this.parent.children.some(child => child.toggleable && child.toggled);
 


### PR DESCRIPTION
Fixed a toggle state bug that occurred when toggling the child of a parent who was not toggled on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rcsideprojects/ramp-vue-testing/29)
<!-- Reviewable:end -->
