### PR TITLE
add options menu to layers + delete user created layers

### DIFF
--- a/ramp/src/classes/LayerState.js
+++ b/ramp/src/classes/LayerState.js
@@ -12,6 +12,7 @@ export class LayerState {
     }
     this.root = curEntry;
     this.isRoot = this.parent === null;
+    this.userAdded = options && options.userAdded !== undefined ? !!options.userAdded : false;
 
     // legend state
     this.expandable = options && options.expandable !== undefined ? !!options.expandable : true;

--- a/ramp/src/components/DropdownComponent.vue
+++ b/ramp/src/components/DropdownComponent.vue
@@ -8,13 +8,22 @@
       <span>{{ element.name }}</span>
 
       <!-- icon -->
-      <div v-if="element.toggleable">
-        <md-button
-          id="icon"
-          class="md-icon-button md-primary md-flat"
-          v-on:click="toggle"
-        >
-          <md-icon class="md-icon-small" v-if="element.toggled" style="width: 20px; height: 20px;">check_box</md-icon>
+      <div id="icon" v-on:click="clickedButton = true">
+        <md-menu style="z-index: 10;" md-size="auto" :md-offset-x="-180" :md-offset-y="-30">
+          <md-icon class="md-icon-small" md-menu-trigger>more_horiz</md-icon>
+
+          <md-menu-content>
+            <md-menu-item v-on:click="remove" :disabled="!element.userAdded">Remove</md-menu-item>
+          </md-menu-content>
+        </md-menu>
+      </div>
+      <div v-if="element.toggleable" v-on:click="clickedButton = true">
+        <md-button id="icon" class="md-icon-button md-primary md-flat" v-on:click="toggle">
+          <md-icon
+            class="md-icon-small"
+            v-if="element.toggled"
+            style="width: 20px; height: 20px;"
+          >check_box</md-icon>
           <md-icon class="md-icon-small" v-else>check_box_outline_blank</md-icon>
         </md-button>
       </div>
@@ -31,15 +40,15 @@ export default {
   props: ["element"],
   data: function() {
     return {
-      clickedToggle: false
+      clickedButton: false
     };
   },
   methods: {
     click: function() {
-      if (!this.clickedToggle) {
+      if (!this.clickedButton) {
         this.element.expanded = !this.element.expanded;
       }
-      this.clickedToggle = false;
+      this.clickedButton = false;
       if (this.element.expanded) {
         this.$store.getters.getEntries.allCollapsed = false;
         this.$store.dispatch("updateHeaderOption", "expanded");
@@ -49,15 +58,26 @@ export default {
       }
     },
     toggle: function() {
-      this.clickedToggle = true;
       this.element.toggle();
       if (this.element.toggled) {
         this.$store.getters.getEntries.allUntoggled = false;
         this.$store.dispatch("updateHeaderOption", "toggled");
       } else {
         this.$store.getters.getEntries.allToggled = false;
-        this.$store.dispatch("updateHeaderOption", "untoggled")
+        this.$store.dispatch("updateHeaderOption", "untoggled");
       }
+    },
+    remove: function() {
+      // first remove children node
+      for (let i = this.element.children.length - 1; i >= 0; i--) {
+        this.element.children.splice(i, 1);
+      }
+
+      // remove this node from the parent
+      let node = this.element.parent.children.findIndex(c => {
+        return c === this.element;
+      });
+      this.element.parent.children.splice(node, 1);
     }
   }
 };

--- a/ramp/src/components/LeafComponent.vue
+++ b/ramp/src/components/LeafComponent.vue
@@ -5,6 +5,15 @@
       <span>{{ element.name }}</span>
 
       <!-- icon -->
+      <div id="icon">
+        <md-menu style="z-index: 10;" md-size="auto" :md-offset-x="-180" :md-offset-y="-30">
+          <md-icon class="md-icon-small" md-menu-trigger>more_horiz</md-icon>
+
+          <md-menu-content>
+            <md-menu-item v-on:click="remove" :disabled='!element.userAdded'>Remove</md-menu-item>
+          </md-menu-content>
+        </md-menu>
+      </div>
       <div v-if="element.toggleable">
         <div id="icon" v-on:click="toggle">
           <md-icon class="md-icon-small" v-if="element.toggled">check_box</md-icon>
@@ -32,8 +41,14 @@ export default {
         this.$store.dispatch("updateHeaderOption", "toggled");
       } else {
         this.$store.getters.getEntries.allToggled = false;
-        this.$store.dispatch("updateHeaderOption", "untoggled")
+        this.$store.dispatch("updateHeaderOption", "untoggled");
       }
+    },
+    remove: function() {
+      let node = this.element.parent.children.findIndex(c => {
+        return c === this.element;
+      });
+      this.element.parent.children.splice(node, 1);
     }
   }
 };

--- a/ramp/src/components/LegendHeader.vue
+++ b/ramp/src/components/LegendHeader.vue
@@ -134,7 +134,8 @@ export default {
             children: [],
             options: {
               expanded: this.initExpanded,
-              toggled: this.initVisibility
+              toggled: this.initVisibility,
+              userAdded: true
             }
           };
           const childNodes = document.querySelector(".rv-group-children");
@@ -147,7 +148,8 @@ export default {
                 name: curChildName,
                 options: {
                   toggled: curChild.children[1].checked,
-                  expanded: curChild.children[2].checked
+                  expanded: curChild.children[2].checked,
+                  userAdded: true
                 }
               });
             } else {
@@ -163,7 +165,8 @@ export default {
             name: this.newEntryName,
             options: {
               expanded: this.initExpanded,
-              toggled: this.initVisibility
+              toggled: this.initVisibility,
+              userAdded: true
             }
           });
           this.newEntryName = "";


### PR DESCRIPTION
This PR adds the ability to delete layers that are added manually by the user.

The delete option currently shows up for drop down components and leaf components. Deleting a drop down component will delete all children nodes.

There are a few visual bugs with the actual drop down menu itself that will need to be fixed at some point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rcsideprojects/ramp-vue-testing/33)
<!-- Reviewable:end -->
