### PR TITLE
removed import for icons

### DIFF
--- a/ramp/src/App.vue
+++ b/ramp/src/App.vue
@@ -8,11 +8,9 @@
 import Legend from "./components/Legend.vue";
 import Vue from "vue";
 import VueMaterial from "vue-material";
-import { MdIcon } from "vue-material/dist/components";
 import "vue-material/dist/vue-material.min.css";
 
 Vue.use(VueMaterial);
-Vue.use(MdIcon);
 
 export default {
   name: "app",


### PR DESCRIPTION
There's no need to import icons directly since we're already importing all components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rcsideprojects/ramp-vue-testing/34)
<!-- Reviewable:end -->
