### PR TITLE
add table controls

### DIFF
--- a/ramp/src/components/GridComponent.vue
+++ b/ramp/src/components/GridComponent.vue
@@ -1,7 +1,46 @@
 <template>
-	<div>
+	<div class="grid-container">
+		<div class="rv-header">
+			<div class="rv-header-content">
+				<h3 class="rv-title">{{ element.name }}</h3>
+
+				<!-- this is a hardcoded value temporarily for testing purposes -->
+				<span class="rv-record-count">1 - 6 of 6 entries shown</span>
+			</div>
+			<span class="flex"></span>
+
+			<!-- table controls -->
+			<div class="rv-table-search">
+				<input
+					@keyup="updateQuickSearch"
+					v-model="quicksearch"
+					placeholder="Search table"
+					class="ng-pristine ng-valid rv-input ng-empty ng-touched"
+					id="input_687"
+					aria-invalid="false"
+					style=""
+				/>
+				<md-icon v-if="!quicksearch">search</md-icon>
+				<span v-if="quicksearch" v-on:click="quicksearch=null;updateQuickSearch()"><md-icon>close</md-icon></span>
+			</div>
+			<span class="rv-button-divider"></span>
+			<md-button id="icon" class="md-icon-button md-primary md-flat md-button-disabled" :disabled="true">
+				<md-icon class="md-icon-small" style="width: 20px; height: 20px;">filter_list</md-icon>
+			</md-button>
+			<md-button id="icon" class="md-icon-button md-primary md-flat">
+				<md-icon class="md-icon-small" style="width: 20px; height: 20px;">format_list_bulleted</md-icon>
+			</md-button>
+			<md-button id="icon" class="md-icon-button md-primary md-flat">
+				<md-icon class="md-icon-small" style="width: 20px; height: 20px;">refresh</md-icon>
+			</md-button>
+			<md-button id="icon" class="md-icon-button md-primary md-flat">
+				<md-icon class="md-icon-small" style="width: 20px; height: 20px;">more_vert</md-icon>
+			</md-button>
+			<md-button id="icon" class="md-icon-button md-primary md-flat" @click="element.tableOpen = false">
+				<md-icon class="md-icon-small" style="width: 20px; height: 20px;">close</md-icon>
+			</md-button>
+		</div>
 		<ag-grid-vue
-			style="width: 500px; height: 300px;"
 			class="ag-grid-test ag-theme-material"
 			:gridOptions="gridOptions"
 			:columnDefs="columnDefs"
@@ -24,11 +63,13 @@ import CustomHeader from './CustomHeader';
 
 export default {
 	name: 'GridComponent',
+	props: ['element'],
 	data() {
 		return {
 			columnDefs: null,
 			rowData: null,
-			modules: AllCommunityModules
+			modules: AllCommunityModules,
+			quicksearch: null
 		};
 	},
 	components: {
@@ -84,6 +125,9 @@ export default {
 		onGridReady(params) {
 			this.gridApi = params.api;
 			this.columnApi = params.columnApi;
+		},
+		updateQuickSearch() {
+			this.gridApi.setQuickFilter(this.quicksearch);
 		}
 	},
 	created() {
@@ -95,7 +139,7 @@ export default {
 </script>
 
 <style>
-.ag-grid-test {
+.grid-container {
 	position: absolute;
 	margin-left: 375px;
 	width: calc(100% - 22vw) !important;
@@ -104,5 +148,69 @@ export default {
 	box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14),
 		0px 2px 1px -1px rgba(0, 0, 0, 0.12);
 	top: 0px;
+}
+.ag-grid-test {
+	height: calc(50vh - 49px);
+}
+.rv-header {
+	display: flex;
+	white-space: nowrap;
+	border-bottom: 1px solid #e0e0e0;
+	height: auto;
+	min-height: 49px;
+	align-items: center;
+	padding: 0 0 0 16px;
+}
+.rv-header-content {
+	overflow: hidden;
+}
+.rv-record-count {
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	width: 100%;
+	overflow: hidden;
+	margin-top: 5px;
+	margin-bottom: 0;
+	line-height: 11px;
+	font-size: 13px;
+}
+.rv-title {
+	margin: 0px;
+	font-size: 20px;
+	font-weight: bold;
+	line-height: 24px;
+	letter-spacing: 0.005em;
+}
+.rv-button-divider {
+	border-right: #b6b6b6 1px solid;
+	margin-right: 10px;
+	margin-left: 10px;
+	height: 26px;
+}
+.rv-input {
+	order: 2;
+	display: inline-block;
+	margin-top: 0;
+	background: none;
+	padding-top: 2px;
+	padding-bottom: 1px;
+	padding-left: 2px;
+	padding-right: 2px;
+	border-width: 0 0 1px 0;
+	border-bottom: 1px solid #ddd;
+	line-height: 26px;
+	height: 30px;
+	-ms-flex-preferred-size: 26px;
+	border-radius: 0;
+	border-style: solid;
+	width: 90%;
+	box-sizing: border-box;
+	outline: 0;
+}
+.flex {
+	flex: 1;
+}
+.md-button-disabled {
+	color: rgba(0, 0, 0, 0.38);
 }
 </style>

--- a/ramp/src/components/LeafComponent.vue
+++ b/ramp/src/components/LeafComponent.vue
@@ -42,7 +42,7 @@
         </md-button>
       </div>
     </div>
-    <GridComponent v-if="element.tableOpen"></GridComponent>
+    <GridComponent :element="element" v-if="element.tableOpen"></GridComponent>
   </div>
 </template>
 


### PR DESCRIPTION
Adds the header, table options and global search features to the table. Currently, the only table option that works is the close button.

Note: some of the icons aren't the same as RAMP3 since the icon pack we're using doesn't have them. This can be fixed at a later date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rcsideprojects/ramp-vue-testing/60)
<!-- Reviewable:end -->
