### PR TITLE
only allow one table open at a time

### DIFF
--- a/ramp/src/components/LeafComponent.vue
+++ b/ramp/src/components/LeafComponent.vue
@@ -72,8 +72,14 @@ export default {
       }
     },
     openTable: function() {
-      // *** find a way to prevent multiple table panels open at once
+      let currentTable = this.$store.getters.getOpenTable;
+
+      if(currentTable != null && currentTable !== this.element) {
+        currentTable.tableOpen = false;
+      }
+
       this.element.tableOpen = !this.element.tableOpen;
+      this.$store.commit('SET_OPEN_TABLE', this.element);
     },
     remove: function() {
       let node = this.element.parent.children.findIndex(c => c === this.element);

--- a/ramp/src/components/SymbologyStackComponent.vue
+++ b/ramp/src/components/SymbologyStackComponent.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="rvDropdown">
-    <div class="rvDropdownTitle noselect" v-on:click="click">
+  <div class="rvDropdown" v-on:click="openTable">
+    <div class="rvDropdownTitle noselect">
       <!-- icon -->
       <md-button id="icon" class="md-icon-button md-primary md-flat" v-if="element.expanded">
         <md-icon class="md-icon-small" style="width: 20px; height: 20px;">clear</md-icon>
       </md-button>
-      <SymbologyStackIcon :stack="element.symbologyStack" v-else></SymbologyStackIcon>
+      <SymbologyStackIcon  v-on:click="click" :stack="element.symbologyStack" v-else></SymbologyStackIcon>
 
       <!-- name -->
-      <span v-on:click="openTable">{{ element.name }}</span>
+      <span>{{ element.name }}</span>
 
       <!-- icon -->
       <div v-if="element.toggleable">
@@ -76,8 +76,14 @@ export default {
       }
     },
     openTable: function() {
-      // *** find a way to prevent multiple table panels open at once
+      let currentTable = this.$store.getters.getOpenTable;
+
+      if(currentTable != null && currentTable !== this.element) {
+        currentTable.tableOpen = false;
+      }
+
       this.element.tableOpen = !this.element.tableOpen;
+      this.$store.commit('SET_OPEN_TABLE', this.element);
     }
   }
 }

--- a/ramp/src/main.ts
+++ b/ramp/src/main.ts
@@ -71,14 +71,16 @@ root.addChild(child3);
 
 const store = new Vuex.Store({
   state: {
-    legendComponents: root
+    legendComponents: root,
+    openTable: null
   },
   getters: {
     getEntries: state => state.legendComponents,
     getAllToggled: state => state.legendComponents.allToggled,
     getAllUntoggled: state => state.legendComponents.allUntoggled,
     getAllExpanded: state => state.legendComponents.allExpanded,
-    getAllCollapsed: state => state.legendComponents.allCollapsed
+    getAllCollapsed: state => state.legendComponents.allCollapsed,
+    getOpenTable: state => state.openTable
   },
   mutations: {
     ADD_ENTRY(state, payload) {
@@ -91,6 +93,9 @@ const store = new Vuex.Store({
     },
     UPDATE_HEADER_OPTIONS (state, option) {
       state.legendComponents.updateHeaderOption(option);
+    },
+    SET_OPEN_TABLE (state, table) {
+      state.openTable = table;
     }
   },
   actions: {


### PR DESCRIPTION
Store the object for the layer whose grid was last opened in the Vuex store. When opening a new grid, we make sure the previously opened grid is closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rcsideprojects/ramp-vue-testing/69)
<!-- Reviewable:end -->
